### PR TITLE
make multi language field in ParallelData optional

### DIFF
--- a/check_data.py
+++ b/check_data.py
@@ -69,9 +69,7 @@ class DataChecker:
             error_map[error['type']].add(error_info)
         errors = []
         for key, values in error_map.items():
-            error_info = ", ".join(list(values)[:3])
-            if len(values) >= 3:
-                error_info += ', ...'
+            error_info = ", ".join(list(values))
             if key == 'missing':
                 errors.append(f'missing error, missing keys: [{error_info}]')
             elif 'type' in key:

--- a/data_types.py
+++ b/data_types.py
@@ -111,26 +111,26 @@ class ParallelParagraph(BaseModel):
     zh_text_md5: str
     zh_text: str
     en_text: str
-    ar_text: str
-    nl_text: str
-    de_text: str
-    eo_text: str
-    fr_text: str
-    he_text: str
-    it_text: str
-    ja_text: str
-    pt_text: str
-    ru_text: str
-    es_text: str
-    sv_text: str
-    ko_text: str
-    th_text: str
-    id_text: str
-    vi_text: str
-    cht_text: str
-    other1_text: str
-    other2_text: str
-    扩展字段: str
+    ar_text: Optional[str] = ''
+    nl_text: Optional[str] = ''
+    de_text: Optional[str] = ''
+    eo_text: Optional[str] = ''
+    fr_text: Optional[str] = ''
+    he_text: Optional[str] = ''
+    it_text: Optional[str] = ''
+    ja_text: Optional[str] = ''
+    pt_text: Optional[str] = ''
+    ru_text: Optional[str] = ''
+    es_text: Optional[str] = ''
+    sv_text: Optional[str] = ''
+    ko_text: Optional[str] = ''
+    th_text: Optional[str] = ''
+    id_text: Optional[str] = ''
+    vi_text: Optional[str] = ''
+    cht_text: Optional[str] = ''
+    other1_text: Optional[str] = ''
+    other2_text: Optional[str] = ''
+    扩展字段: Optional[str] = ''
 
 
 class ParallelData(BaseModel):
@@ -141,7 +141,7 @@ class ParallelData(BaseModel):
     去重段落数: int
     低质量段落数: int
     段落: List[ParallelParagraph]
-    扩展字段: str
+    扩展字段: Optional[str] = ''
     时间: str
 
     @classmethod


### PR DESCRIPTION
https://github.com/X94521/DataCheck_MNBVC/issues/6 的解决方案

附上一个之前做的泰拉瑞亚的测试用例：


这个是3月16号做的老数据
```json
{"文件名": "Terraria-workshop-localization_test1.jsonl", "是否待查文件": false, "是否重复文件": false, "段落数": 17944, "去重段落数": 0, "低质量段落数": 0, "段落": [{"行号": 1, "是否重复": false, "是否跨文件重复": false, "zh_text": "正在生成海洋沙", "en_text": "Generating ocean sand", "ar_text": "", "nl_text": "", "de_text": "", "eo_text": "", "fr_text": "Génération du sable de l'océan", "he_text": "", "it_text": "", "ja_text": "", "pt_text": "Gerando areia do oceano", "ru_text": "Создание песка в океане", "es_text": "", "sv_text": "", "ko_text": "", "th_text": "", "other1_text": "", "other2_text": "", "拓展字段": "{}", "时间": "20240316", "hu_text": "Tengeri homok elhelyezése", "uk_text": "Генерація океанського піску", "zh_text_md5": "b656579704c6ca5acc29f2aa36159ce2"}], "拓展字段": "{}", "时间": "20240316"}
```

这个是为了兼容现在的新schema不得不修改的
```json
{"文件名": "Terraria-workshop-localization_test2.jsonl", "是否待查文件": false, "是否重复文件": false, "段落数": 17944, "去重段落数": 0, "低质量段落数": 0, "段落": [{"行号": 1, "是否重复": false, "是否跨文件重复": false, "it_text":"","zh_text": "正在生成海洋沙", "en_text": "Generating ocean sand", "ar_text": "", "nl_text": "", "de_text": "", "eo_text": "", "fr_text": "Génération du sable de l'océan", "he_text": "", "it_text": "", "ja_text": "", "pt_text": "Gerando areia do oceano", "ru_text": "Создание песка в океане", "es_text": "", "sv_text": "", "ko_text": "", "th_text": "", "other1_text": "", "other2_text": "", "id_text":"","cht_text":"","vi_text":"","扩展字段": "{}", "时间": "20240316", "hu_text": "Tengeri homok elhelyezése", "uk_text": "Генерація океанського піску", "zh_text_md5": "b656579704c6ca5acc29f2aa36159ce2"}], "扩展字段": "{}", "时间": "20240316"}
```

这个是本次提交修改后去除了无效数据仍然能够通过检测的
```json
{"文件名": "Terraria-workshop-localization_test3.jsonl", "是否待查文件": false, "是否重复文件": false, "段落数": 17944, "去重段落数": 0, "低质量段落数": 0, "段落": [{"行号": 1, "是否重复": false, "是否跨文件重复": false, "zh_text": "正在生成海洋沙", "en_text": "Generating ocean sand", "fr_text": "Génération du sable de l'océan", "pt_text": "Gerando areia do oceano", "ru_text": "Создание песка в океане", "hu_text": "Tengeri homok elhelyezése", "uk_text": "Генерація океанського піску", "zh_text_md5": "b656579704c6ca5acc29f2aa36159ce2"}], "扩展字段": "{}", "时间": "20240316"}
```

我认为平行语料做格式检测的目的应该是告诉小组成员什么语言应该用什么缩写，而不是强制要求所有语言都必须填一个值上去。这边还麻烦评估一下这个改动能不能接受